### PR TITLE
fix: Correct 'orderby' parameter for getCategories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,7 @@
 
 - Improved API structure and documentation.
 - Added interceptors property to Woocommerce class
+
+# 1.2.2
+
+- Fixes issue #23 in category orderby queryParameter.

--- a/lib/src/category/api/category_api.dart
+++ b/lib/src/category/api/category_api.dart
@@ -17,7 +17,7 @@ extension WooCategoryApi on WooCommerce {
   ///
   /// [order] Order sort attribute ascending or descending. Options: asc and desc. Default is desc.
   ///
-  /// [orderBy] Sort collection by object attribute. Options: date, id, include, title, slug, price, popularity and rating. Default is date.
+  /// [orderBy] Sort collection by resource attribute. Options: id, include, name, slug, term_group, description and count. Default is name.
   ///
   /// [hideEmpty] Whether to hide resources not assigned to any products. Default is false.
   ///
@@ -36,7 +36,7 @@ extension WooCategoryApi on WooCommerce {
     List<int>? exclude,
     List<int>? include,
     WooSortOrder order = WooSortOrder.desc,
-    WooSortOrderBy orderBy = WooSortOrderBy.date,
+    WooCategoryOrderBy orderBy = WooCategoryOrderBy.name,
     bool? hideEmpty,
     int? parent,
     int? product,
@@ -80,7 +80,7 @@ extension WooCategoryApi on WooCommerce {
     required List<int>? exclude,
     required List<int>? include,
     required WooSortOrder order,
-    required WooSortOrderBy orderBy,
+    required WooCategoryOrderBy orderBy,
     required bool? hideEmpty,
     required int? parent,
     required int? product,

--- a/lib/src/category/enums/enums.dart
+++ b/lib/src/category/enums/enums.dart
@@ -1,1 +1,2 @@
 export 'category_display.dart';
+export 'order_by.dart';

--- a/lib/src/category/enums/order_by.dart
+++ b/lib/src/category/enums/order_by.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: constant_identifier_names
+
+enum WooCategoryOrderBy {
+  id,
+  include,
+  name,
+  slug,
+  term_group,
+  description,
+  count,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: woocommerce_flutter_api
 description: A Flutter package for WooCommerce integration. Manage products, orders, and customers with updated dependencies for seamless e-commerce.
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/loaidev64/woocommerce_flutter_api.git
 platforms:
   android:


### PR DESCRIPTION
Resolves the 'rest_invalid_param' error when calling getCategories() without parameters by making a new enum that matches the values in the WooCommerce REST API.

Closes #23 