### PR TITLE
fix: nullable dates in WooProductImage + enum conversion in WooProductCategory.display (v1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.1
+
+- **Fix `WooProductImage` for product creation**: all four `DateTime` fields (`dateCreated`, `dateCreatedGMT`, `dateModified`, `dateModifiedGMT`) are now nullable and optional in the positional constructor. `fromJson` keeps them as `null` when missing, and `toJson` only emits them when present, so product creation payloads no longer trigger `400 Bad Request` from the WooCommerce API. Fixes #31.
+- **Fix `WooProductCategory.display` serialization**: `fromJson` now uses `WooCategoryDisplay.fromString` to convert the API string into the enum, and `toJson` writes `"default"` (without the trailing underscore) instead of the enum's `default_` name. Fixes #30.
+
 ## 1.7.0
 
 - Updated `flutter_secure_storage` to `^11.0.0` (WASM-compatible).

--- a/lib/src/category/models/category.dart
+++ b/lib/src/category/models/category.dart
@@ -123,7 +123,9 @@ class WooProductCategory {
     slug = json['slug'];
     parent = json['parent'];
     description = json['description'];
-    display = json['display'];
+    display = json['display'] != null
+        ? WooCategoryDisplay.fromString(json['display'] as String)
+        : null;
     image = json['image'] != null
         ? WooProductCategoryImage.fromJson(json['image'])
         : null;
@@ -232,7 +234,7 @@ class WooProductCategory {
     data['slug'] = slug;
     data['parent'] = parent;
     data['description'] = description;
-    data['display'] = display;
+    data['display'] = display?.name.replaceAll('_', '');
     if (image != null) {
       data['image'] = image!.toJson();
     }

--- a/lib/src/product/models/product_image.dart
+++ b/lib/src/product/models/product_image.dart
@@ -3,19 +3,40 @@ import 'package:woocommerce_flutter_api/src/helpers/fake_helper.dart';
 /// Represents a product image with metadata and URLs.
 ///
 /// Brief description of the model's purpose and usage for product images.
+///
+/// ## Product creation note
+///
+/// When creating a product, the WooCommerce REST API only accepts
+/// `id`, `src`, `name` and `alt` inside the `images` array. The four
+/// date fields below are populated by the server on read and should
+/// be left `null` (the default) when constructing an image for a
+/// create request — otherwise the API returns `400 Bad Request`.
 class WooProductImage {
   /// Creates a new WooProductImage instance.
-  WooProductImage(this.id, this.src, this.name, this.alt, this.dateCreated,
-      this.dateCreatedGMT, this.dateModified, this.dateModifiedGMT);
+  ///
+  /// The four date parameters are optional. Omit them when building
+  /// a payload for product creation; the server will generate them.
+  /// Set them when deserializing a response.
+  WooProductImage(
+    this.id,
+    this.src,
+    this.name,
+    this.alt, [
+    this.dateCreated,
+    this.dateCreatedGMT,
+    this.dateModified,
+    this.dateModifiedGMT,
+  ]);
 
   /// Creates a WooProductImage instance from JSON data.
+  ///
+  /// Date fields that are missing or empty in [json] are kept as `null`.
   WooProductImage.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        // Note: Consider adding type checks or defaults if API might return null for non-nullable DateTime fields
-        dateCreated = DateTime.parse(json['date_created']),
-        dateCreatedGMT = DateTime.parse(json['date_created_gmt']),
-        dateModified = DateTime.parse(json['date_modified']),
-        dateModifiedGMT = DateTime.parse(json['date_modified_gmt']),
+        dateCreated = _parseDate(json['date_created']),
+        dateCreatedGMT = _parseDate(json['date_created_gmt']),
+        dateModified = _parseDate(json['date_modified']),
+        dateModifiedGMT = _parseDate(json['date_modified_gmt']),
         src = json['src'],
         name = json['name'],
         alt = json['alt'];
@@ -36,16 +57,16 @@ class WooProductImage {
   final int? id;
 
   /// The date the image was created, in the site's timezone.
-  final DateTime dateCreated;
+  final DateTime? dateCreated;
 
   /// The date the image was created, as GMT.
-  final DateTime dateCreatedGMT;
+  final DateTime? dateCreatedGMT;
 
   /// The date the image was last modified, in the site's timezone.
-  final DateTime dateModified;
+  final DateTime? dateModified;
 
   /// The date the image was last modified, as GMT.
-  final DateTime dateModifiedGMT;
+  final DateTime? dateModifiedGMT;
 
   /// Image URL.
   final String? src;
@@ -58,19 +79,25 @@ class WooProductImage {
 
   /// Converts this WooProductImage instance into a JSON encodable Map.
   ///
-  /// Note: When updating/creating products, typically only 'id' or 'src' is needed
-  /// within the 'images' list. Sending all fields might be unnecessary or ignored
-  /// by the specific WooCommerce API endpoint context. Check API docs for specifics.
+  /// Only emits date keys when they are non-null, so payloads for
+  /// product creation omit them entirely (the server assigns them).
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = {};
-    // Only include fields if they are not null, except for DateTime which are required
     if (id != null) {
       data['id'] = id;
     }
-    data['date_created'] = dateCreated.toIso8601String();
-    data['date_created_gmt'] = dateCreatedGMT.toIso8601String();
-    data['date_modified'] = dateModified.toIso8601String();
-    data['date_modified_gmt'] = dateModifiedGMT.toIso8601String();
+    if (dateCreated != null) {
+      data['date_created'] = dateCreated!.toIso8601String();
+    }
+    if (dateCreatedGMT != null) {
+      data['date_created_gmt'] = dateCreatedGMT!.toIso8601String();
+    }
+    if (dateModified != null) {
+      data['date_modified'] = dateModified!.toIso8601String();
+    }
+    if (dateModifiedGMT != null) {
+      data['date_modified_gmt'] = dateModifiedGMT!.toIso8601String();
+    }
     if (src != null) {
       data['src'] = src;
     }
@@ -88,7 +115,7 @@ class WooProductImage {
     return 'WooProductImage(id: $id, src: $src, name: $name, alt: $alt, dateCreated: $dateCreated, dateCreatedGMT: $dateCreatedGMT, dateModified: $dateModified, dateModifiedGMT: $dateModifiedGMT)';
   }
 
-  // Optional: Add copyWith method for easier updates
+  /// Returns a copy of this WooProductImage with the given fields replaced.
   WooProductImage copyWith({
     int? id,
     DateTime? dateCreated,
@@ -109,5 +136,10 @@ class WooProductImage {
       dateModified ?? this.dateModified,
       dateModifiedGMT ?? this.dateModifiedGMT,
     );
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is String && value.isNotEmpty) return DateTime.parse(value);
+    return null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: woocommerce_flutter_api
 description: A Flutter package for WooCommerce integration. Manage products, orders, and customers with updated dependencies for seamless e-commerce.
-version: 1.7.0
+version: 1.7.1
 repository: https://github.com/loaidev64/woocommerce_flutter_api.git
 platforms:
   android:


### PR DESCRIPTION
Closes #30, closes #31.

Two real bug fixes for a 1.7.1 patch release:

**#31 — `WooProductImage` breaks product creation**
The four `DateTime` fields (`dateCreated`, `dateCreatedGMT`, `dateModified`, `dateModifiedGMT`) were non-nullable. WooCommerce's `POST /products` rejects those fields on the images payload, so `createProduct(` ... `images: [...WooProductImage(null, src, name, alt, DateTime.now(), ...)]`` returned 400 Bad Request. Fix: make all four dates nullable + optional in the positional constructor, parse them safely in `fromJson` (`null` when missing/empty), and emit them in `toJson` only when present.

**#30 — `WooProductCategory.display` runtime TypeError**
`fromJson` assigned a raw `String` to a `WooCategoryDisplay?` field (crash) and `toJson` serialized the enum by name, emitting `"default_"` (with the trailing underscore) instead of the API's required `"default"`. The existing `WooCategoryDisplay.fromString` helper was unused. Fix: deserialize via `WooCategoryDisplay.fromString` and serialize via `display?.name.replaceAll('_', '')`.

Pure bug-fix PR. No dependency changes. `dart format` and `flutter analyze` are green. v1.7.1 changelog entry added.